### PR TITLE
Feature/update node

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - name: Install dependencies
         run: yarn install
         env:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "http-errors": "^1.8.0",
     "lodash": "^4.17.15",
     "mime-types": "^2.1.26",
-    "serverless-http": "^2.3.1",
+    "serverless-http": "^3.2.0",
     "uuid": "^3.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/lodash": "^4.14.157",
     "@types/mime-types": "^2.1.0",
     "@types/mock-req-res": "^1.1.2",
-    "@types/node": "^12",
+    "@types/node": "^14",
     "@types/uuid": "^3.4.7",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
@@ -102,6 +102,6 @@
     "url": "git://github.com/awslabs/fhir-works-on-aws-routing.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- Updates node, as AWS deprecated node 12 for AWS Lambda. 
- Updates serverless-http package as serverless framework was updated to v3 (also required due to node12 deprecation)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.